### PR TITLE
pythonのversionを返すapiを作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,138 +1,50 @@
 # sam-swagger-sample-api
 
-This project contains source code and supporting files for a serverless application that you can deploy with the SAM CLI. It includes the following files and folders.
+SAM ＋ Swagger で API を作成するサンプル。
 
-- hello_world - Code for the application's Lambda function.
-- events - Invocation events that you can use to invoke the function.
-- tests - Unit tests for the application code. 
-- template.yaml - A template that defines the application's AWS resources.
+## Dependency
 
-The application uses several AWS resources, including Lambda functions and an API Gateway API. These resources are defined in the `template.yaml` file in this project. You can update the template to add AWS resources through the same deployment process that updates your application code.
+```
+$ python --version
+Python 3.7.5
 
-If you prefer to use an integrated development environment (IDE) to build and test your application, you can use the AWS Toolkit.  
-The AWS Toolkit is an open source plug-in for popular IDEs that uses the SAM CLI to build and deploy serverless applications on AWS. The AWS Toolkit also adds a simplified step-through debugging experience for Lambda function code. See the following links to get started.
+$ pip --version
+pip 19.2.3 from /usr/local/lib/python3.7/site-packages/pip (python 3.7)
 
-* [PyCharm](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
-* [IntelliJ](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html)
-* [VS Code](https://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/welcome.html)
-* [Visual Studio](https://docs.aws.amazon.com/toolkit-for-visual-studio/latest/user-guide/welcome.html)
-
-## Deploy the sample application
-
-The Serverless Application Model Command Line Interface (SAM CLI) is an extension of the AWS CLI that adds functionality for building and testing Lambda applications. It uses Docker to run your functions in an Amazon Linux environment that matches Lambda. It can also emulate your application's build environment and API.
-
-To use the SAM CLI, you need the following tools.
-
-* AWS CLI - [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure it with your AWS credentials].
-* SAM CLI - [Install the SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
-* [Python 3 installed](https://www.python.org/downloads/)
-* Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
-
-The SAM CLI uses an Amazon S3 bucket to store your application's deployment artifacts. If you don't have a bucket suitable for this purpose, create one. Replace `BUCKET_NAME` in the commands in this section with a unique bucket name.
-
-```bash
-sam-swagger-sample-api$ aws s3 mb s3://BUCKET_NAME
+$ sam --version
+SAM CLI, version 0.22.0
 ```
 
-To prepare the application for deployment, use the `sam package` command.
+## Setup
 
-```bash
-sam-swagger-sample-api$ sam package \
-    --output-template-file packaged.yaml \
-    --s3-bucket BUCKET_NAME
+```
+$ pip install pip==19.2.3 aws-sam-cli==0.22.0
+
+$ aws s3 mb s3://iam326.sam-swagger-sample
 ```
 
-The SAM CLI creates deployment packages, uploads them to the S3 bucket, and creates a new version of the template that refers to the artifacts in the bucket. 
+## Usage
 
-To deploy the application, use the `sam deploy` command.
-
-```bash
-sam-swagger-sample-api$ sam deploy \
-    --template-file packaged.yaml \
-    --stack-name sam-swagger-sample-api \
-    --capabilities CAPABILITY_IAM
+```
+./deploy.sh
 ```
 
-After deployment is complete you can run the following command to retrieve the API Gateway Endpoint URL:
+## Memo
 
-```bash
-sam-swagger-sample-api$ aws cloudformation describe-stacks \
-    --stack-name sam-swagger-sample-api \
-    --query 'Stacks[].Outputs[?OutputKey==`HelloWorldApi`]' \
-    --output table
-``` 
+- 雛形作成
 
-## Use the SAM CLI to build and test locally
-
-Build your application with the `sam build` command.
-
-```bash
-sam-swagger-sample-api$ sam build
+```
+$ sam init --runtime python3.7 --name sam-swagger-sample-api
 ```
 
-The SAM CLI installs dependencies defined in `hello_world/requirements.txt`, creates a deployment package, and saves it in the `.aws-sam/build` folder.
+- Swagger Editor の起動
 
-Test a single function by invoking it directly with a test event. An event is a JSON document that represents the input that the function receives from the event source. Test events are included in the `events` folder in this project.
-
-Run functions locally and invoke them with the `sam local invoke` command.
-
-```bash
-sam-swagger-sample-api$ sam local invoke HelloWorldFunction --event events/event.json
+```
+$ docker pull swaggerapi/swagger-editor
+$ docker run -d -p 80:8080 swaggerapi/swagger-editor
+http://localhost/
 ```
 
-The SAM CLI can also emulate your application's API. Use the `sam local start-api` to run the API locally on port 3000.
+- Lambda の Runtime で指定した Python のバージョンと、ローカルのバージョンを合わせる必要がある
 
-```bash
-sam-swagger-sample-api$ sam local start-api
-sam-swagger-sample-api$ curl http://localhost:3000/
-```
-
-The SAM CLI reads the application template to determine the API's routes and the functions that they invoke. The `Events` property on each function's definition includes the route and method for each path.
-
-```yaml
-      Events:
-        HelloWorld:
-          Type: Api
-          Properties:
-            Path: /hello
-            Method: get
-```
-
-## Add a resource to your application
-The application template uses AWS Serverless Application Model (AWS SAM) to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources such as functions, triggers, and APIs. For resources not included in [the SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use standard [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html) resource types.
-
-## Fetch, tail, and filter Lambda function logs
-
-To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs` lets you fetch logs generated by your deployed Lambda function from the command line. In addition to printing the logs on the terminal, this command has several nifty features to help you quickly find the bug.
-
-`NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
-
-```bash
-sam-swagger-sample-api$ sam logs -n HelloWorldFunction --stack-name sam-swagger-sample-api --tail
-```
-
-You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).
-
-## Unit tests
-
-Tests are defined in the `tests` folder in this project. Use PIP to install the [pytest](https://docs.pytest.org/en/latest/) and run unit tests.
-
-```bash
-sam-swagger-sample-api$ pip install pytest pytest-mock --user
-sam-swagger-sample-api$ python -m pytest tests/ -v
-```
-
-## Cleanup
-
-To delete the sample application and the bucket that you created, use the AWS CLI.
-
-```bash
-sam-swagger-sample-api$ aws cloudformation delete-stack --stack-name sam-swagger-sample-api
-sam-swagger-sample-api$ aws s3 rb s3://BUCKET_NAME
-```
-
-## Resources
-
-See the [AWS SAM developer guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html) for an introduction to SAM specification, the SAM CLI, and serverless application concepts.
-
-Next, you can use AWS Serverless Application Repository to deploy ready to use Apps that go beyond hello world samples and learn how authors developed their applications: [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/)
+- 記載した pip や sam 以外のバージョンを使用すると、`sam build`でエラーが発生する可能性がある

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly STACK_NAME="sam-swagger-sample"
+readonly BUCKET_NAME="iam326.${STACK_NAME}"
+
+aws s3 cp swagger.yaml s3://${BUCKET_NAME}/swagger.yaml
+
+sam build
+
+sam package \
+  --output-template-file packaged.yaml \
+  --s3-bucket ${BUCKET_NAME}
+
+sam deploy \
+  --template-file packaged.yaml \
+  --stack-name ${STACK_NAME} \
+  --capabilities CAPABILITY_IAM
+
+rm packaged.yaml
+
+readonly APIURL=$(aws cloudformation describe-stacks \
+  --stack-name ${STACK_NAME} \
+  --output text \
+  --query 'Stacks[].Outputs[?OutputKey==`PythonVersionApiUrl`].OutputValue' \
+)
+
+readonly APIKEY_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${STACK_NAME} \
+  --output text \
+  --query 'Stacks[].Outputs[?OutputKey==`SampleApiKey`].OutputValue' \
+)
+
+readonly APIKEY=$(aws apigateway get-api-key \
+  --api-key ${APIKEY_ID} \
+  --include-value \
+  --output text \
+  --query 'value' \
+)
+
+echo "curl -H \"x-api-key: ${APIKEY}\" ${APIURL}"

--- a/hello_world/app.py
+++ b/hello_world/app.py
@@ -1,42 +1,13 @@
 import json
-
-# import requests
+import sys
 
 
 def lambda_handler(event, context):
-    """Sample pure Lambda function
 
-    Parameters
-    ----------
-    event: dict, required
-        API Gateway Lambda Proxy Input Format
-
-        Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
-
-    context: object, required
-        Lambda Context runtime methods and attributes
-
-        Context doc: https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html
-
-    Returns
-    ------
-    API Gateway Lambda Proxy Output Format: dict
-
-        Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
-    """
-
-    # try:
-    #     ip = requests.get("http://checkip.amazonaws.com/")
-    # except requests.RequestException as e:
-    #     # Send some context about this error to Lambda Logs
-    #     print(e)
-
-    #     raise e
-
-    return {
-        "statusCode": 200,
-        "body": json.dumps({
-            "message": "hello world",
-            # "location": ip.text.replace("\n", "")
-        }),
-    }
+  version = f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}'
+  return {
+      "statusCode": 200,
+      "body": json.dumps({
+          "python": version
+      })
+  }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,0 +1,49 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Sample API
+  description: Sample of Swagger & API Gateway
+basePath: /Prod
+tags:
+  - name: Version
+schemes:
+  - https
+paths:
+  /version:
+    get:
+      tags:
+        - Version
+      summary: PythonのVersion取得
+      description: Lambdaで動作するPythonのVersionを取得する
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        200:
+          description: successful operation
+          schema:
+            $ref: "#/definitions/Version"
+      x-amazon-apigateway-integration:
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PythonVersionFunction.Arn}/invocations
+        passthroughBehavior: when_no_templates
+        httpMethod: POST
+        type: aws_proxy
+      security:
+        - SampleApiKey: []
+
+securityDefinitions:
+  SampleApiKey:
+    type: apiKey
+    name: x-api-key
+    in: header
+
+definitions:
+  Version:
+    type: object
+    required:
+      - python
+    properties:
+      python:
+        type: string

--- a/template.yaml
+++ b/template.yaml
@@ -1,39 +1,75 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: >
-  sam-swagger-sample-api
+Description: sam-swagger-sample-api
 
-  Sample SAM Template for sam-swagger-sample-api
-
-# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
     Timeout: 3
 
 Resources:
-  HelloWorldFunction:
-    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+  PythonVersionApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      DefinitionBody:
+        Fn::Transform:
+          Name: AWS::Include
+          Parameters:
+            Location: s3://iam326.sam-swagger-sample/swagger.yaml
+
+  SampleApiKey:
+    Type: AWS::ApiGateway::ApiKey
+    DependsOn:
+      - PythonVersionApi
+      - PythonVersionApiProdStage
+    Properties:
+      Name: sample-api-key
+      Enabled: true
+      StageKeys:
+        - RestApiId: !Ref PythonVersionApi
+          StageName: Prod
+
+  SampleApiUsagePlan:
+    Type: AWS::ApiGateway::UsagePlan
+    DependsOn:
+      - PythonVersionApi
+      - PythonVersionApiProdStage
+    Properties:
+      ApiStages:
+        - ApiId: !Ref PythonVersionApi
+          Stage: Prod
+      Throttle:
+        BurstLimit: 200
+        RateLimit: 100
+      UsagePlanName: sample-api-usage-plan
+
+  SampleApiUsagePlanKey:
+    Type: AWS::ApiGateway::UsagePlanKey
+    DependsOn:
+      - SampleApiKey
+      - SampleApiUsagePlan
+    Properties:
+      KeyId: !Ref SampleApiKey
+      KeyType: API_KEY
+      UsagePlanId: !Ref SampleApiUsagePlan
+
+  PythonVersionFunction:
+    Type: AWS::Serverless::Function
     Properties:
       CodeUri: hello_world/
       Handler: app.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.7
       Events:
-        HelloWorld:
-          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+        GetVersion:
+          Type: Api
           Properties:
-            Path: /hello
+            Path: /version
             Method: get
+            RestApiId: !Ref PythonVersionApi
 
 Outputs:
-  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
-  # Find out more about other implicit resources you can reference within SAM
-  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
-  HelloWorldApi:
-    Description: "API Gateway endpoint URL for Prod stage for Hello World function"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
-  HelloWorldFunction:
-    Description: "Hello World Lambda Function ARN"
-    Value: !GetAtt HelloWorldFunction.Arn
-  HelloWorldFunctionIamRole:
-    Description: "Implicit IAM Role created for Hello World function"
-    Value: !GetAtt HelloWorldFunctionRole.Arn
+  PythonVersionApiUrl:
+    Description: API Gateway endpoint URL for Prod stage for Python Version Function
+    Value: !Sub https://${PythonVersionApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/version
+  SampleApiKey:
+    Value: !Ref SampleApiKey


### PR DESCRIPTION
[参考]
* [【初心者向け】SwaggerとAWS SAMを使ってWebAPIを簡単に作ってみた](https://dev.classmethod.jp/cloud/aws/serverless-swagger-apigateway/)
* [SAM で API Gateway に API Key を設定する](https://qiita.com/couzie/items/88596971787c5fac3a27)
* [AWS SAMでAPIキーと使用量プランのリソース作成に失敗する場合の対処方法](https://qiita.com/hayao_k/items/4bee4a27a2b15f19fad8)