### PR TITLE
api gatewayとcognitoを組み合わせる

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ $ aws s3 mb s3://iam326.sam-swagger-sample
 $ ./deploy.sh
 ```
 
+### CREATE USER
+
+```
+$ ./cognito-create-user.sh <USERNAME> <EMAIL> <PASSWORD>
+```
+
 ### Unit Test
 
 ```

--- a/cognito-create-user.sh
+++ b/cognito-create-user.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly STACK_NAME="sam-swagger-sample"
+
+readonly USERNAME=$1
+readonly EMAIL=$2
+readonly PASSWORD=$3
+
+readonly USER_POOL_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${STACK_NAME} \
+  --output text \
+  --query 'Stacks[].Outputs[?OutputKey==`UserPoolId`].OutputValue' \
+)
+
+readonly USER_POOL_CLIENT_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${STACK_NAME} \
+  --output text \
+  --query 'Stacks[].Outputs[?OutputKey==`UserPoolClientId`].OutputValue' \
+)
+
+USER=$(aws cognito-idp admin-create-user \
+  --user-pool-id ${USER_POOL_ID} \
+  --username ${USERNAME} \
+  --user-attributes Name=email,Value=${EMAIL} \
+  --temporary-password=${PASSWORD} \
+  --message-action=SUPPRESS
+)
+
+AUTH_CHALLENGE_SESSION=$(aws cognito-idp initiate-auth \
+  --auth-flow USER_PASSWORD_AUTH \
+  --client-id ${USER_POOL_CLIENT_ID} \
+  --auth-parameters "USERNAME=${USERNAME},PASSWORD=${PASSWORD}" \
+  --query "Session" \
+  --output text
+)
+
+AUTH_TOKEN=$(aws cognito-idp respond-to-auth-challenge \
+  --client-id ${USER_POOL_CLIENT_ID} \
+  --challenge-responses "NEW_PASSWORD=${PASSWORD},USERNAME=${USERNAME}" \
+  --challenge-name NEW_PASSWORD_REQUIRED \
+  --session ${AUTH_CHALLENGE_SESSION} \
+  --query "AuthenticationResult.IdToken" \
+  --output text
+)
+
+echo ${AUTH_TOKEN}

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,17 +26,4 @@ readonly APIURL=$(aws cloudformation describe-stacks \
   --query 'Stacks[].Outputs[?OutputKey==`PythonVersionApiUrl`].OutputValue' \
 )
 
-readonly APIKEY_ID=$(aws cloudformation describe-stacks \
-  --stack-name ${STACK_NAME} \
-  --output text \
-  --query 'Stacks[].Outputs[?OutputKey==`SampleApiKey`].OutputValue' \
-)
-
-readonly APIKEY=$(aws apigateway get-api-key \
-  --api-key ${APIKEY_ID} \
-  --include-value \
-  --output text \
-  --query 'value' \
-)
-
-echo "curl -H \"x-api-key: ${APIKEY}\" ${APIURL}"
+echo ${APIURL}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -30,14 +30,6 @@ paths:
         passthroughBehavior: when_no_templates
         httpMethod: POST
         type: aws_proxy
-      security:
-        - SampleApiKey: []
-
-securityDefinitions:
-  SampleApiKey:
-    type: apiKey
-    name: x-api-key
-    in: header
 
 definitions:
   Version:

--- a/template.yaml
+++ b/template.yaml
@@ -7,51 +7,94 @@ Globals:
     Timeout: 3
 
 Resources:
+  UserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: sample-user-pool
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: true
+      MfaConfiguration: "OFF"
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 6
+          RequireLowercase: false
+          RequireNumbers: false
+          RequireSymbols: false
+          RequireUppercase: false
+          TemporaryPasswordValidityDays: 7
+
+  UserPoolClient:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+      ClientName: sample-user-pool-client
+      ExplicitAuthFlows:
+        - USER_PASSWORD_AUTH
+      GenerateSecret: false
+      RefreshTokenValidity: 30
+      UserPoolId: !Ref UserPool
+
+  IdentityPool:
+    Type: AWS::Cognito::IdentityPool
+    Properties:
+      AllowUnauthenticatedIdentities: false
+      IdentityPoolName: sample-id-pool
+      CognitoIdentityProviders:
+        - ClientId: !Ref UserPoolClient
+          ProviderName: !Sub "cognito-idp.${AWS::Region}.amazonaws.com/${UserPool}"
+
+  AuthenticatedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - mobileanalytics:PutEvents
+              - cognito-sync:*
+              - cognito-identity:*
+            Resource:
+              - "*"
+
+  AuthenticatedRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRoleWithWebIdentity
+            Principal:
+              Federated: cognito-identity.amazonaws.com
+            Condition:
+              StringEquals:
+                "cognito-identity.amazonaws.com:aui": !Ref IdentityPool
+              ForAnyValue:StringLike:
+                "cognito-identity.amazonaws.com:amr": authenticated
+      ManagedPolicyArns:
+        - !Ref AuthenticatedPolicy
+
+  RoleAttachment:
+    Type: AWS::Cognito::IdentityPoolRoleAttachment
+    Properties:
+      IdentityPoolId: !Ref IdentityPool
+      Roles:
+        authenticated: !GetAtt AuthenticatedRole.Arn
+
   PythonVersionApi:
     Type: AWS::Serverless::Api
     Properties:
       StageName: Prod
+      Auth:
+        DefaultAuthorizer: CognitoAuthorizer
+        Authorizers:
+          CognitoAuthorizer:
+            UserPoolArn: !GetAtt UserPool.Arn
       DefinitionBody:
         Fn::Transform:
           Name: AWS::Include
           Parameters:
             Location: s3://iam326.sam-swagger-sample/swagger.yaml
-
-  SampleApiKey:
-    Type: AWS::ApiGateway::ApiKey
-    DependsOn:
-      - PythonVersionApi
-      - PythonVersionApiProdStage
-    Properties:
-      Name: sample-api-key
-      Enabled: true
-      StageKeys:
-        - RestApiId: !Ref PythonVersionApi
-          StageName: Prod
-
-  SampleApiUsagePlan:
-    Type: AWS::ApiGateway::UsagePlan
-    DependsOn:
-      - PythonVersionApi
-      - PythonVersionApiProdStage
-    Properties:
-      ApiStages:
-        - ApiId: !Ref PythonVersionApi
-          Stage: Prod
-      Throttle:
-        BurstLimit: 200
-        RateLimit: 100
-      UsagePlanName: sample-api-usage-plan
-
-  SampleApiUsagePlanKey:
-    Type: AWS::ApiGateway::UsagePlanKey
-    DependsOn:
-      - SampleApiKey
-      - SampleApiUsagePlan
-    Properties:
-      KeyId: !Ref SampleApiKey
-      KeyType: API_KEY
-      UsagePlanId: !Ref SampleApiUsagePlan
 
   PythonVersionFunction:
     Type: AWS::Serverless::Function
@@ -71,5 +114,11 @@ Outputs:
   PythonVersionApiUrl:
     Description: API Gateway endpoint URL for Prod stage for Python Version Function
     Value: !Sub https://${PythonVersionApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/version
-  SampleApiKey:
-    Value: !Ref SampleApiKey
+  UserPoolId:
+    Value: !Ref UserPool
+  UserPoolArn:
+    Value: !GetAtt UserPool.Arn
+  UserPoolClientId:
+    Value: !Ref UserPoolClient
+  IdentityPoolId:
+    Value: !Ref IdentityPool

--- a/template.yaml
+++ b/template.yaml
@@ -10,7 +10,7 @@ Resources:
   UserPool:
     Type: AWS::Cognito::UserPool
     Properties:
-      UserPoolName: sample-user-pool
+      UserPoolName: !Sub "${AWS::StackName}-user-pool"
       AdminCreateUserConfig:
         AllowAdminCreateUserOnly: true
       MfaConfiguration: "OFF"
@@ -26,7 +26,7 @@ Resources:
   UserPoolClient:
     Type: AWS::Cognito::UserPoolClient
     Properties:
-      ClientName: sample-user-pool-client
+      ClientName: !Sub "${AWS::StackName}-user-pool-client"
       ExplicitAuthFlows:
         - USER_PASSWORD_AUTH
       GenerateSecret: false
@@ -37,7 +37,7 @@ Resources:
     Type: AWS::Cognito::IdentityPool
     Properties:
       AllowUnauthenticatedIdentities: false
-      IdentityPoolName: sample-id-pool
+      IdentityPoolName: !Sub "${AWS::StackName}-id-pool"
       CognitoIdentityProviders:
         - ClientId: !Ref UserPoolClient
           ProviderName: !Sub "cognito-idp.${AWS::Region}.amazonaws.com/${UserPool}"


### PR DESCRIPTION
[参考]

* [ユーザープール認証フロー](https://docs.aws.amazon.com/ja_jp/cognito/latest/developerguide/amazon-cognito-user-pools-authentication-flow.html)
* [jeffisadams/lambda-cognito-go](https://github.com/jeffisadams/lambda-cognito-go/blob/1155c62b42653c6499f7558c221b1dc6a6e630d5/scripts/login_first.sh)
* [CloudFormation で Cognito](https://qiita.com/y13i/items/1923b47079bdf7c44eec)
* [CloudFormationでCognito User Pool（E メールアドレスおよび電話番号）](https://qiita.com/konoui/items/4ba7e3a419f5895df3c2)
* [AWS SAMでCognito UserPoolsの認証付きAPIを作成する](https://blog.youyo.info/post/2018/12/05/sam-apigateway-authorizer/)
* [MFAを有効化したCognitoユーザープールよりCLIでToken取得](https://www.skyarch.net/blog/?p=15254)
* [AWS CLIを使ってCognitoユーザーステータスのFORCE_CHANGE_PASSWORDをCONFIRMEDにしてみる](https://dev.classmethod.jp/cloud/aws/change-cognito-user-force_change_passwore-to-confirmed/)